### PR TITLE
move positioned widget to the top of stack

### DIFF
--- a/lib/flutter_stories.dart
+++ b/lib/flutter_stories.dart
@@ -260,6 +260,18 @@ class _StoryState extends State<Story> with SingleTickerProviderStateMixin {
     return Stack(
       fit: StackFit.expand,
       children: <Widget>[
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: GestureDetector(
+            onTapDown: _onTapDown,
+            onTapUp: _onTapUp,
+            onLongPress: _onLongPress,
+            onLongPressUp: _onLongPressEnd,
+          ),
+        ),
         widget.momentBuilder(
           context,
           _currentIdx < widget.momentCount
@@ -302,18 +314,6 @@ class _StoryState extends State<Story> with SingleTickerProviderStateMixin {
                 )
               ],
             ),
-          ),
-        ),
-        Positioned(
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          child: GestureDetector(
-            onTapDown: _onTapDown,
-            onTapUp: _onTapUp,
-            onLongPress: _onLongPress,
-            onLongPressUp: _onLongPressEnd,
           ),
         ),
       ],


### PR DESCRIPTION
Solved the Problem in which Interactive widget in the story not abel to receive the events.
Even we touch on the button story view receive the event and not passing to the **Button**.

When two interactive widgets placed on the stack it gives highest preference to the widget which is placed on the last of stack 
It gives the highest preference to the GestureDetector which is placed last in the stack.
